### PR TITLE
Ignore test_ros2cli sub-package.

### DIFF
--- a/eloquent.ignored
+++ b/eloquent.ignored
@@ -1,0 +1,1 @@
+test_ros2cli


### PR DESCRIPTION
We don't release it and this breaks a circular dependency
with ros_testing.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>